### PR TITLE
Multiple code improvements - squid:S1213, squid:S1192, squid:ClassVariableVisibilityCheck, squid:S1640, squid:S2386, squid:S1151

### DIFF
--- a/land-core/src/main/java/com/oldratlee/land/launcher/LandLauncher.java
+++ b/land-core/src/main/java/com/oldratlee/land/launcher/LandLauncher.java
@@ -9,12 +9,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author ding.lid
@@ -36,14 +31,14 @@ public class LandLauncher {
 
     private static final LandLauncher launcher = new LandLauncher();
 
+    public static final Map<String, LandClassLoader> app2LandClassLoaderMap = new HashMap<>();
+
     public static LandLauncher getLauncher() {
         return launcher;
     }
 
-    public static Map<String, LandClassLoader> app2LandClassLoaderMap = new HashMap<>();
-
     public ClassLoader createClassLoader(final URL[] urls) {
-        return new LandClassLoader(urls, new HashMap<DelegateType, List<String>>());
+        return new LandClassLoader(urls, new EnumMap<DelegateType, List<String>>(DelegateType.class));
     }
 
     public static void main(String[] args) throws IOException {
@@ -93,7 +88,7 @@ public class LandLauncher {
     }
 
     static Map<DelegateType, List<String>> convertDelegateConfigs(String delegateConfigs) {
-        Map<DelegateType, List<String>> ret = new LinkedHashMap<>();
+        Map<DelegateType, List<String>> ret = new EnumMap<>(DelegateType.class);
 
         String[] delegateConfigArray = delegateConfigs.split("\\s*;\\s*");
         for (String delegateConfig : delegateConfigArray) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1192 - String literals should not be duplicated.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1640 - Maps with keys that are enum values should be replaced with EnumMap.
squid:S2386 - Mutable fields should not be "public static".
squid:S1151 - "switch case" clauses should not have too many lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1640
https://dev.eclipse.org/sonar/rules/show/squid:S2386
https://dev.eclipse.org/sonar/rules/show/squid:S1151
Please let me know if you have any questions.
George Kankava