### PR TITLE
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime

### DIFF
--- a/land-test-helper/land-test-helper-api/src/main/java/com/bar/api/ApiC0.java
+++ b/land-test-helper/land-test-helper-api/src/main/java/com/bar/api/ApiC0.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class ApiC0 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", ApiC0.class.getName(), ApiC0.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", ApiC0.class.getName(), ApiC0.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/Foo.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/Foo.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class Foo {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", Foo.class.getName(), Foo.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", Foo.class.getName(), Foo.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C1.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P1C1 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P1C1.class.getName(), P1C1.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P1C1.class.getName(), P1C1.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C2.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P1C2 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P1C2.class.getName(), P1C2.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P1C2.class.getName(), P1C2.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C1.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P11C1 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P11C1.class.getName(), P11C1.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P11C1.class.getName(), P11C1.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C2.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P11C2 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P11C2.class.getName(), P11C2.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P11C2.class.getName(), P11C2.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C1.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P2C1 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P2C1.class.getName(), P2C1.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P2C1.class.getName(), P2C1.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C2.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P2C2 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P2C2.class.getName(), P2C2.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P2C2.class.getName(), P2C2.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C1.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P21C1 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P21C1.class.getName(), P21C1.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P21C1.class.getName(), P21C1.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C2.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class P21C2 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", P21C2.class.getName(), P21C2.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", P21C2.class.getName(), P21C2.class.getClassLoader());
     }
 
     public static void main(String[] args) {

--- a/land-test-helper/land-test-helper-impl/src/main/java/com/bar/impl/ImplC0.java
+++ b/land-test-helper/land-test-helper-impl/src/main/java/com/bar/impl/ImplC0.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class ImplC0 {
     static {
-        System.out.printf("loaded class %s by class loader %s.\n", ImplC0.class.getName(), ImplC0.class.getClassLoader());
+        System.out.printf("loaded class %s by class loader %s.%n", ImplC0.class.getName(), ImplC0.class.getClassLoader());
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2275
Please let me know if you have any questions.
George Kankava