### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/land-test-helper/land-test-helper-api/src/main/java/com/bar/api/ApiC0.java
+++ b/land-test-helper/land-test-helper-api/src/main/java/com/bar/api/ApiC0.java
@@ -10,6 +10,8 @@ public class ApiC0 {
         System.out.printf("loaded class %s by class loader %s.\n", ApiC0.class.getName(), ApiC0.class.getClassLoader());
     }
 
+    private ApiC0() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         ApiC0 foo = new ApiC0();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/Foo.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/Foo.java
@@ -10,6 +10,8 @@ public class Foo {
         System.out.printf("loaded class %s by class loader %s.\n", Foo.class.getName(), Foo.class.getClassLoader());
     }
 
+    private Foo() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         Foo foo = new Foo();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C1.java
@@ -10,6 +10,8 @@ public class P1C1 {
         System.out.printf("loaded class %s by class loader %s.\n", P1C1.class.getName(), P1C1.class.getClassLoader());
     }
 
+    private P1C1() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P1C1 foo = new P1C1();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/P1C2.java
@@ -10,6 +10,8 @@ public class P1C2 {
         System.out.printf("loaded class %s by class loader %s.\n", P1C2.class.getName(), P1C2.class.getClassLoader());
     }
 
+    private P1C2() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P1C2 foo = new P1C2();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C1.java
@@ -10,6 +10,8 @@ public class P11C1 {
         System.out.printf("loaded class %s by class loader %s.\n", P11C1.class.getName(), P11C1.class.getClassLoader());
     }
 
+    private P11C1() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P11C1 foo = new P11C1();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p1/p11/P11C2.java
@@ -10,6 +10,8 @@ public class P11C2 {
         System.out.printf("loaded class %s by class loader %s.\n", P11C2.class.getName(), P11C2.class.getClassLoader());
     }
 
+    private P11C2() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P11C2 foo = new P11C2();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C1.java
@@ -10,6 +10,8 @@ public class P2C1 {
         System.out.printf("loaded class %s by class loader %s.\n", P2C1.class.getName(), P2C1.class.getClassLoader());
     }
 
+    private P2C1() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P2C1 foo = new P2C1();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/P2C2.java
@@ -10,6 +10,8 @@ public class P2C2 {
         System.out.printf("loaded class %s by class loader %s.\n", P2C2.class.getName(), P2C2.class.getClassLoader());
     }
 
+    private P2C2() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P2C2 foo = new P2C2();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C1.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C1.java
@@ -10,6 +10,8 @@ public class P21C1 {
         System.out.printf("loaded class %s by class loader %s.\n", P21C1.class.getName(), P21C1.class.getClassLoader());
     }
 
+    private P21C1() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P21C1 foo = new P21C1();

--- a/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C2.java
+++ b/land-test-helper/land-test-helper-common/src/main/java/com/foo/p2/p21/P21C2.java
@@ -10,6 +10,8 @@ public class P21C2 {
         System.out.printf("loaded class %s by class loader %s.\n", P21C2.class.getName(), P21C2.class.getClassLoader());
     }
 
+    private P21C2() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         P21C2 foo = new P21C2();

--- a/land-test-helper/land-test-helper-impl/src/main/java/com/bar/impl/ImplC0.java
+++ b/land-test-helper/land-test-helper-impl/src/main/java/com/bar/impl/ImplC0.java
@@ -10,6 +10,8 @@ public class ImplC0 {
         System.out.printf("loaded class %s by class loader %s.\n", ImplC0.class.getName(), ImplC0.class.getClassLoader());
     }
 
+    private ImplC0() {}
+
     public static void main(String[] args) {
         System.out.println("args is: " + Arrays.toString(args));
         ImplC0 foo = new ImplC0();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava